### PR TITLE
# Change Default CLI Behavior and Improve Output Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+.pr_prompt/

--- a/README.md
+++ b/README.md
@@ -40,25 +40,25 @@ print(prompt)
 
 ### 🖥️ CLI Usage
 ```bash
-# Review prompt (default type) to review.md
+# Review prompt (default type) to stdout
 pr-prompt
 
-# Review prompt to stdout
-pr-prompt review --stdout
+# Review prompt saved to .pr_prompt/review.md
+pr-prompt review --write
 
-# Description prompt to description.md
+# Description prompt to stdout
 pr-prompt description -b main
 
 # Custom prompt (requires custom_instructions in TOML config)
 pr-prompt custom
 ```
-Writes `<type>.md` unless `--stdout` is used.
+Outputs to stdout by default. Use `--write` to save to `.pr_prompt/<type>.md`.
 
 Flags:
 - `--base-ref / -b` base branch or commit
 - `--blacklist` repeatable pattern exclusion
 - `--context` repeatable pattern inclusion
-- `--stdout` print instead of file
+- `--write` save to `.pr_prompt/<type>.md` instead of stdout
 
 ## ⚙️ Configuration
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Arbitrary instructions. Requires:
 ## 📋 Prompt Structure
 Generated Markdown sections:
 - Instructions: Role plus review / description / custom goals.
-- Pull Request Details: Repository name, base -> head branch, optional title/description, commit list.
+- Pull Request Details: Repository name, base -> head branch, optional description, commit list.
 - Context Files: Inline content from context_patterns for architectural / design background.
 - Changed Files Tree: Condensed tree view of modified paths.
 - File Diffs: Diffs filtered by blacklist_patterns with configured context lines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pr-prompt"
-version = "0.5.0"
+version = "1.0.0"
 description = "A tool to generate pull request prompts using git cli commands."
 authors = [{ name = "Oskar Bonde", email = "oskar.bonde@gmail.com" }]
 license = "MIT"
@@ -33,7 +33,7 @@ build-backend = "uv_build"
 
 # ===================== bumpversion =====================
 [tool.bumpversion]
-current_version = "0.5.0"
+current_version = "1.0.0"
 
 [[tool.bumpversion.files]]
 filename = "src/pr_prompt/__init__.py"

--- a/src/pr_prompt/__init__.py
+++ b/src/pr_prompt/__init__.py
@@ -2,5 +2,5 @@
 
 from .generator import PrPromptGenerator
 
-__version__ = "0.5.0"
+__version__ = "1.0.0"
 __all__ = ["PrPromptGenerator"]

--- a/src/pr_prompt/cli.py
+++ b/src/pr_prompt/cli.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Annotated, Callable
 
 import typer
+from git import Repo
 from rich.console import Console
-from rich.markdown import Markdown
 
 from . import __version__
 from .generator import PrPromptGenerator
@@ -88,14 +88,15 @@ def generate(
     if write:
         output_dir = Path(".pr_prompt")
         output_dir.mkdir(exist_ok=True)
-        output_path = output_dir / f"{prompt_type.value}.md"
+        short_sha = get_short_sha()
+        output_path = output_dir / f"{prompt_type.value}_{short_sha}.md"
         output_path.write_text(prompt, encoding="utf-8")
         console.print(
             f"✅ Wrote pr {prompt_type.value} prompt to {output_path}", style="green"
         )
         console.print(f"File size: {len(prompt):,} characters", style="blue")
     else:
-        console.print(Markdown(prompt))
+        console.print(prompt)
 
 
 def get_overrides(
@@ -118,6 +119,12 @@ def get_generator_method(
     if prompt_type == PromptType.DESCRIPTION:
         return generator.generate_description
     return generator.generate_custom
+
+
+def get_short_sha() -> str:
+    """Get the 7-character short SHA of the current HEAD commit."""
+    repo = Repo()
+    return repo.head.commit.hexsha[:7]
 
 
 def main() -> None:

--- a/src/pr_prompt/cli.py
+++ b/src/pr_prompt/cli.py
@@ -47,11 +47,11 @@ def generate(
             help="The branch/commit to compare against (e.g., 'main'). Infer from default branch if not provided",
         ),
     ] = None,
-    stdout: Annotated[  # noqa: FBT002
+    write: Annotated[  # noqa: FBT002
         bool,
         typer.Option(
-            "--stdout",
-            help="Output to stdout instead of writing to file",
+            "--write",
+            help="Write to .pr_prompt/<type>.md instead of stdout",
         ),
     ] = False,
     blacklist: Annotated[
@@ -78,22 +78,24 @@ def generate(
     ] = False,
 ) -> None:
     """Generate a pull request prompt."""
-    if not stdout:
+    if write:
         console.print(f"Generating pr {prompt_type.value} prompt...", style="dim")
     overrides = get_overrides(blacklist, context)
     generator = PrPromptGenerator.from_toml(**overrides)
     generator_method = get_generator_method(generator, prompt_type)
     prompt = generator_method(base_ref)
 
-    if stdout:
-        console.print(Markdown(prompt))
-    else:
-        output_path = Path(f"{prompt_type.value}.md")
+    if write:
+        output_dir = Path(".pr_prompt")
+        output_dir.mkdir(exist_ok=True)
+        output_path = output_dir / f"{prompt_type.value}.md"
         output_path.write_text(prompt, encoding="utf-8")
         console.print(
             f"✅ Wrote pr {prompt_type.value} prompt to {output_path}", style="green"
         )
         console.print(f"File size: {len(prompt):,} characters", style="blue")
+    else:
+        console.print(Markdown(prompt))
 
 
 def get_overrides(

--- a/src/pr_prompt/generator.py
+++ b/src/pr_prompt/generator.py
@@ -112,6 +112,8 @@ class PrPromptGenerator:
         self,
         base_ref: Optional[str] = None,
         head_ref: Optional[str] = None,
+        *,
+        pr_description: Optional[str] = None,
     ) -> str:
         """
         Generate a prompt for creating PR descriptions.
@@ -119,13 +121,13 @@ class PrPromptGenerator:
         Args:
             base_ref: The base branch/commit to compare against. If None, uses default_base_branch.
             head_ref: The branch/commit with changes. Default: current branch.
-
+            pr_description: The description of the pull request.
         """
         return self._generate(
             DESCRIPTION_INSTRUCTIONS,
             base_ref or self.default_base_branch,
             head_ref,
-            pr_description=None,
+            pr_description=pr_description,
         )
 
     def generate_custom(

--- a/src/pr_prompt/generator.py
+++ b/src/pr_prompt/generator.py
@@ -28,7 +28,6 @@ class PrPromptGenerator:
             default_base_branch="main",
         )
         prompt = generator.generate_review(
-            pr_title="Add new authentication system",
             pr_description="Implements OAuth2 with JWT tokens",
         )
         ```
@@ -92,7 +91,6 @@ class PrPromptGenerator:
         base_ref: Optional[str] = None,
         head_ref: Optional[str] = None,
         *,
-        pr_title: Optional[str] = None,
         pr_description: Optional[str] = None,
     ) -> str:
         """
@@ -101,14 +99,12 @@ class PrPromptGenerator:
         Args:
             base_ref: The base branch/commit to compare against. If None, uses default_base_branch.
             head_ref: The branch/commit with changes. Default: current branch.
-            pr_title: The title of the pull request.
             pr_description: The description of the pull request.
         """
         return self._generate(
             REVIEW_INSTRUCTIONS,
             base_ref or self.default_base_branch,
             head_ref,
-            pr_title=pr_title,
             pr_description=pr_description,
         )
 
@@ -116,8 +112,6 @@ class PrPromptGenerator:
         self,
         base_ref: Optional[str] = None,
         head_ref: Optional[str] = None,
-        *,
-        pr_title: Optional[str] = None,
     ) -> str:
         """
         Generate a prompt for creating PR descriptions.
@@ -125,14 +119,12 @@ class PrPromptGenerator:
         Args:
             base_ref: The base branch/commit to compare against. If None, uses default_base_branch.
             head_ref: The branch/commit with changes. Default: current branch.
-            pr_title: The title of the pull request.
 
         """
         return self._generate(
             DESCRIPTION_INSTRUCTIONS,
             base_ref or self.default_base_branch,
             head_ref,
-            pr_title=pr_title,
             pr_description=None,
         )
 
@@ -142,7 +134,6 @@ class PrPromptGenerator:
         head_ref: Optional[str] = None,
         *,
         instructions: Optional[str] = None,
-        pr_title: Optional[str] = None,
         pr_description: Optional[str] = None,
     ) -> str:
         """
@@ -152,7 +143,6 @@ class PrPromptGenerator:
             base_ref: The base branch/commit to compare against. If None, uses default_base_branch.
             head_ref: The branch/commit with changes. Default: current branch.
             instructions: Custom instructions for the LLM. If None, uses custom_instructions.
-            pr_title: The title of the pull request.
             pr_description: The description of the pull request.
 
         """
@@ -164,7 +154,6 @@ class PrPromptGenerator:
             final_instructions,
             base_ref or self.default_base_branch,
             head_ref,
-            pr_title=pr_title,
             pr_description=pr_description,
         )
 
@@ -174,7 +163,6 @@ class PrPromptGenerator:
         base_ref: Optional[str] = None,
         head_ref: Optional[str] = None,
         *,
-        pr_title: Optional[str] = None,
         pr_description: Optional[str] = None,
     ) -> str:
         """Generate a pull request prompt."""
@@ -191,7 +179,6 @@ class PrPromptGenerator:
 
         builder.add_metadata(
             include_commit_messages=self.include_commit_messages,
-            pr_title=pr_title,
             pr_description=pr_description,
         )
 

--- a/src/pr_prompt/instructions/description_instructions.py
+++ b/src/pr_prompt/instructions/description_instructions.py
@@ -5,7 +5,6 @@ Your task is to create a clear and concise PR description that includes the foll
 - Summary: A brief summary of the changes made in the PR
 - Motivation: The reason why these changes were necessary
 - Changes Made: A list of the changes implemented. Similar to commit messages
-- Breaking Changes: Highlight any breaking changes
 
 Keep in mind that reviewers also have access to the code diffs, so avoid redundancy and focus on high-level context and rationale.
 """

--- a/src/pr_prompt/instructions/description_instructions.py
+++ b/src/pr_prompt/instructions/description_instructions.py
@@ -2,9 +2,10 @@ DESCRIPTION_INSTRUCTIONS = """You are an expert software engineer writing a pull
 
 Your task is to create a clear and concise PR description that includes the following sections:
 - Title: A short, descriptive title for the PR
-- Changes Made: A summary of the changes implemented
-- Why: The reason why these changes were necessary
-- Note Breaking Changes: Highlight any breaking changes or migration steps
+- Summary: A brief summary of the changes made in the PR
+- Motivation: The reason why these changes were necessary
+- Changes Made: A list of the changes implemented. Similar to commit messages
+- Breaking Changes: Highlight any breaking changes
 
-Keep in mind that reviewers also have access to the code diffs and commit messages, so avoid redundancy and focus on high-level context and rationale.
+Keep in mind that reviewers also have access to the code diffs, so avoid redundancy and focus on high-level context and rationale.
 """

--- a/src/pr_prompt/instructions/description_instructions.py
+++ b/src/pr_prompt/instructions/description_instructions.py
@@ -1,12 +1,10 @@
-DESCRIPTION_INSTRUCTIONS = """
-You are an expert software engineer writing a pull request description.
+DESCRIPTION_INSTRUCTIONS = """You are an expert software engineer writing a pull request description.
 
-Your task:
-- Summarize Changes: Describe what this PR accomplishes
-- Explain Context: Why these changes were needed
-- Document Impact: What areas of the codebase are affected
+Your task is to create a clear and concise PR description that includes the following sections:
+- Title: A short, descriptive title for the PR
+- Changes Made: A summary of the changes implemented
+- Why: The reason why these changes were necessary
 - Note Breaking Changes: Highlight any breaking changes or migration steps
-- Be Clear: Write for other developers who will review and maintain this code
 
-Create a clear, comprehensive PR description that helps reviewers understand the changes.
+Keep in mind that reviewers also have access to the code diffs and commit messages, so avoid redundancy and focus on high-level context and rationale.
 """

--- a/src/pr_prompt/markdown_builder.py
+++ b/src/pr_prompt/markdown_builder.py
@@ -42,7 +42,6 @@ class MarkdownBuilder:
         self,
         *,
         include_commit_messages: bool,
-        pr_title: Optional[str],
         pr_description: Optional[str],
     ) -> None:
         """Add PR metadata section."""
@@ -53,9 +52,6 @@ class MarkdownBuilder:
         content_parts.append(
             f"**Branch:** `{self.git_client.head_ref}` -> `{self.git_client.base_ref}`"
         )
-
-        if pr_title:
-            content_parts.append(f"**Title:** {pr_title}")
 
         if pr_description:
             content_parts.append(f"**Description:**\n\n{pr_description}")

--- a/tests/test_pr_prompt.py
+++ b/tests/test_pr_prompt.py
@@ -38,17 +38,16 @@ class TestMarkdownBuilder:
     """Test prompt building functionality."""
 
     def test_add_metadata_with_title_only(self, mock_git_client: MagicMock) -> None:
-        """Test adding metadata with only title."""
+        """Test adding metadata with description."""
         builder = MarkdownBuilder(mock_git_client)
         builder.add_metadata(
             include_commit_messages=False,
-            pr_title="Fix bug in authentication",
-            pr_description=None,
+            pr_description="Fix bug in authentication",
         )
 
         prompt = builder.build()
         assert "Fix bug in authentication" in prompt
-        assert "**Title:**" in prompt
+        assert "**Description:**" in prompt
 
     def test_add_changed_files(self) -> None:
         """Test changed files display."""
@@ -111,8 +110,9 @@ class TestPrPrompt:
         prompt = generator.generate_review(
             base_ref="origin/main",
             head_ref="feature/test",
-            pr_title="Test PR",
+            pr_description="Test PR",
         )
         assert "Test PR" in prompt
         assert "main.py" in prompt
+        assert "File diffs" in prompt
         assert "File diffs" in prompt


### PR DESCRIPTION
## Summary

This PR changes the default CLI behavior to output directly to stdout instead of writing files, and enhances the output file naming to include git commit SHA for better tracking.

## Motivation

The previous default behavior of writing files to the working directory wasn't ideal for typical CLI usage patterns. Users expect CLI tools to output to stdout by default, allowing for easy piping and redirection. The change makes the tool more intuitive and follows standard CLI conventions.

## Changes Made

- **Changed CLI default behavior**: Now outputs to stdout by default instead of writing to files
- **Updated flag semantics**: Replaced `--stdout` flag with `--write` flag (inverted logic)
- **Enhanced output file naming**: Added git SHA to output filenames for better tracking (e.g., `review_051b9e9.md`)
- **Improved output directory**: Files are now written to .pr_prompt directory instead of current directory
- **Removed PR title support**: Eliminated `pr_title` parameter from all generation methods and CLI
- **Updated instructions**: Refined description instructions to be more structured and specific
- **Updated gitignore**: Added .pr_prompt directory to gitignore
- **Updated documentation**: Modified README to reflect new default behavior and flag changes

## Breaking Changes

- **CLI behavior change**: Default output is now stdout instead of file writing
- **Flag change**: `--stdout` flag removed, replaced with `--write` flag
- **API change**: Removed `pr_title` parameter from `generate_review()`, `generate_description()`, and `generate_custom()` methods
- **Output location change**: When using `--write`, files are saved to .pr_prompt directory instead of current directory