### PR TITLE
Fix git diff to use merge-base, add whitelist filtering, and improve binary file handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+README.md

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ alias desc='uvx pr-prompt description | xclip -selection clipboard'
 
 ### 🔧 Parameters Reference
 PrPromptGenerator / CLI / TOML shared parameters:
-- `blacklist_patterns` `(list[str])` File patterns to exclude from diffs and context file inclusion. Default: `["*.lock", "package-lock.json", "*.exe", "*.dll", "*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]`
+- `blacklist_patterns` `(list[str])` File patterns to exclude from diffs and context file inclusion. Default: `["*.lock", "package-lock.json"]`. Note: binary files are automatically detected and excluded.
 - `whitelist_patterns` `(list[str] | None)` File patterns to include in diffs. Only matching files are shown. Applied after blacklist filtering. Default: `None` (include all)
-- `context_patterns` `(list[str])` File patterns to include in prompt (after blacklist filtering). Default: `["AGENTS.md"]`
+- `context_patterns` `(list[str] | None)` File patterns to include in prompt (after blacklist filtering). Default: `None`
 - `fetch_base` `(bool)` Fetch base ref before generating diff. Default: `False`
 - `diff_context_lines` `(int)` Number of context lines around changes in diffs. Default: `999999`
 - `include_commit_messages` `(bool)` Include commit messages in prompt. Default: `True`
@@ -136,9 +136,9 @@ Modified `src/pr_prompt/__init__.py`
 ### 🔧 Default Configuration
 ```toml
 [tool.pr-prompt]
-blacklist_patterns = ["*.lock", "package-lock.json", "*.exe", "*.dll", "*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]
+blacklist_patterns = ["*.lock", "package-lock.json"]
 # whitelist_patterns =
-context_patterns = ["AGENTS.md"]
+# context_patterns =
 fetch_base = false
 diff_context_lines = 999999
 include_commit_messages = true

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ alias desc='uvx pr-prompt description | xclip -selection clipboard'
 
 ### 🔧 Parameters Reference
 PrPromptGenerator / CLI / TOML shared parameters:
-- `blacklist_patterns` `(list[str])` File patterns to exclude from diffs and context file inclusion. Default: `["*.lock"]`
+- `blacklist_patterns` `(list[str])` File patterns to exclude from diffs and context file inclusion. Default: `["*.lock", "package-lock.json", "*.exe", "*.dll", "*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]`
 - `context_patterns` `(list[str])` File patterns to include in prompt (after blacklist filtering). Default: `["AGENTS.md"]`
 - `fetch_base` `(bool)` Fetch base ref before generating diff. Default: `False`
 - `diff_context_lines` `(int)` Number of context lines around changes in diffs. Default: `999999`
@@ -104,7 +104,7 @@ Arbitrary instructions. Requires:
 - Set `custom_instructions` in constructor/TOML (used when CLI type=custom)
 
 ## 📄 Prompt Example
-~~~markdown
+```markdown
 ## Instructions
 You are a senior software engineer...
 
@@ -123,18 +123,18 @@ M      └── `__init__.py`
 
 ## File diffs
 Modified `src/pr_prompt/__init__.py`
-```diff
+~~~diff
 -__version__ = "0.3.0"
 +__version__ = "0.4.0"
-```
 ~~~
+```
 
 ## ⚙️ Using pyproject.toml / pr_prompt.toml
 
 ### 🔧 Default Configuration
 ```toml
 [tool.pr-prompt]
-blacklist_patterns = ["*.lock"]
+blacklist_patterns = ["*.lock", "package-lock.json", "*.exe", "*.dll", "*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]
 context_patterns = ["AGENTS.md"]
 fetch_base = false
 diff_context_lines = 999999

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options:
 - `--base-ref / -b` base branch or commit
 - `--write` save to `.pr_prompt/<type>_<timestamp>.md` instead of stdout
 - `--blacklist` repeatable pattern exclusion
+- `--whitelist` repeatable pattern to limit diff to matching files only
 - `--context` repeatable pattern inclusion
 - `--fetch / --no-fetch` fetch the base ref before diff. Default: `False`
 
@@ -70,6 +71,7 @@ alias desc='uvx pr-prompt description | xclip -selection clipboard'
 ### 🔧 Parameters Reference
 PrPromptGenerator / CLI / TOML shared parameters:
 - `blacklist_patterns` `(list[str])` File patterns to exclude from diffs and context file inclusion. Default: `["*.lock", "package-lock.json", "*.exe", "*.dll", "*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]`
+- `whitelist_patterns` `(list[str] | None)` File patterns to include in diffs. Only matching files are shown. Applied after blacklist filtering. Default: `None` (include all)
 - `context_patterns` `(list[str])` File patterns to include in prompt (after blacklist filtering). Default: `["AGENTS.md"]`
 - `fetch_base` `(bool)` Fetch base ref before generating diff. Default: `False`
 - `diff_context_lines` `(int)` Number of context lines around changes in diffs. Default: `999999`
@@ -135,6 +137,7 @@ Modified `src/pr_prompt/__init__.py`
 ```toml
 [tool.pr-prompt]
 blacklist_patterns = ["*.lock", "package-lock.json", "*.exe", "*.dll", "*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]
+# whitelist_patterns =
 context_patterns = ["AGENTS.md"]
 fetch_base = false
 diff_context_lines = 999999

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pr-prompt"
-version = "1.2.1"
+version = "1.3.0"
 description = "A tool to generate pull request prompts using git cli commands."
 authors = [{ name = "Oskar Bonde", email = "oskar.bonde@gmail.com" }]
 license = "MIT"
@@ -31,7 +31,7 @@ build-backend = "uv_build"
 
 # ===================== bumpversion =====================
 [tool.bumpversion]
-current_version = "1.2.1"
+current_version = "1.3.0"
 
 [[tool.bumpversion.files]]
 filename = "src/pr_prompt/__init__.py"

--- a/src/pr_prompt/__init__.py
+++ b/src/pr_prompt/__init__.py
@@ -2,5 +2,5 @@
 
 from .generator import PrPromptGenerator
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 __all__ = ["PrPromptGenerator"]

--- a/src/pr_prompt/cli.py
+++ b/src/pr_prompt/cli.py
@@ -31,7 +31,7 @@ class PromptType(str, Enum):
 
 
 @app.command()
-def generate(
+def generate(  # noqa: PLR0913
     prompt_type: Annotated[
         PromptType,
         typer.Argument(
@@ -61,6 +61,13 @@ def generate(
             help="File patterns to exclude from diff and context files. Can be used multiple times.",
         ),
     ] = None,
+    whitelist: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--whitelist",
+            help="File patterns to include in diff. Only matching files are shown. Can be used multiple times.",
+        ),
+    ] = None,
     context: Annotated[
         list[str] | None,
         typer.Option(
@@ -88,7 +95,9 @@ def generate(
     """Generate a pull request prompt."""
     if write:
         console.print(f"Generating pr {prompt_type.value} prompt...", style="dim")
-    overrides = get_overrides(blacklist, context, fetch)
+    overrides = get_overrides(
+        blacklist=blacklist, whitelist=whitelist, context=context, fetch=fetch
+    )
     generator = PrPromptGenerator.from_toml(**overrides)
     generator_method = get_generator_method(generator, prompt_type)
     prompt = generator_method(base_ref)
@@ -101,13 +110,17 @@ def generate(
 
 
 def get_overrides(
+    *,
     blacklist: list[str] | None,
+    whitelist: list[str] | None = None,
     context: list[str] | None,
-    fetch: bool | None,  # noqa: FBT001
+    fetch: bool | None,
 ) -> dict[str, list[str] | bool]:
     overrides: dict[str, list[str] | bool] = {}
     if blacklist is not None:
         overrides["blacklist_patterns"] = blacklist
+    if whitelist is not None:
+        overrides["whitelist_patterns"] = whitelist
     if context is not None:
         overrides["context_patterns"] = context
     if fetch is not None:

--- a/src/pr_prompt/generator.py
+++ b/src/pr_prompt/generator.py
@@ -34,14 +34,13 @@ class PrPromptGenerator:
 
     Attributes:
         blacklist_patterns: File patterns to exclude from diffs and context file inclusion.
-            Default: `["*.lock", "package-lock.json", "*.exe",
-                "*.dll","*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]`.
+            Default: `["*.lock", "package-lock.json"]`.
         whitelist_patterns: File patterns to include in diffs. When set, only files
             matching these patterns are included. Applied after blacklist filtering.
             Default: `None` (include all non-blacklisted files).
         context_patterns: File patterns to include in prompt (after blacklist filtering).
             Used for including documentation that provides context.
-            Default: `["AGENTS.md"]`.
+            Default: `None`.
         fetch_base: Fetch base ref before generating diff.
             Default: `False`.
         diff_context_lines: Number of context lines around changes in diffs.
@@ -59,21 +58,10 @@ class PrPromptGenerator:
     """
 
     blacklist_patterns: list[str] = field(
-        default_factory=lambda: [
-            "*.lock",
-            "package-lock.json",
-            "*.exe",
-            "*.dll",
-            "*.bin",
-            "*.pyc",
-            "*.whl",
-            "*.jar",
-            "*.svg",
-            "*.png",
-        ]
+        default_factory=lambda: ["*.lock", "package-lock.json"]
     )
     whitelist_patterns: Optional[list[str]] = None
-    context_patterns: list[str] = field(default_factory=lambda: ["AGENTS.md"])
+    context_patterns: Optional[list[str]] = None
 
     fetch_base: bool = False
     diff_context_lines: int = 999999

--- a/src/pr_prompt/generator.py
+++ b/src/pr_prompt/generator.py
@@ -22,8 +22,7 @@ class PrPromptGenerator:
     Example:
         ```python
         generator = PrPromptGenerator(
-            blacklist_patterns=["*.lock", "*.png"],
-            context_patterns=["AGENTS.md"],
+            blacklist_patterns=["*.lock", "package-lock.json"],
             include_commit_messages=True,
             default_base_branch="origin/main",
         )

--- a/src/pr_prompt/generator.py
+++ b/src/pr_prompt/generator.py
@@ -36,6 +36,9 @@ class PrPromptGenerator:
         blacklist_patterns: File patterns to exclude from diffs and context file inclusion.
             Default: `["*.lock", "package-lock.json", "*.exe",
                 "*.dll","*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]`.
+        whitelist_patterns: File patterns to include in diffs. When set, only files
+            matching these patterns are included. Applied after blacklist filtering.
+            Default: `None` (include all non-blacklisted files).
         context_patterns: File patterns to include in prompt (after blacklist filtering).
             Used for including documentation that provides context.
             Default: `["AGENTS.md"]`.
@@ -69,6 +72,7 @@ class PrPromptGenerator:
             "*.png",
         ]
     )
+    whitelist_patterns: Optional[list[str]] = None
     context_patterns: list[str] = field(default_factory=lambda: ["AGENTS.md"])
 
     fetch_base: bool = False
@@ -86,8 +90,10 @@ class PrPromptGenerator:
 
         Args:
             **overrides: Keyword arguments to override TOML config values.
-                Supported keys: blacklist_patterns, context_patterns, fetch_base, diff_context_lines,
-                include_commit_messages, repo_path, remote, default_base_branch, custom_instructions.
+                Supported keys: blacklist_patterns, whitelist_patterns, context_patterns, fetch_base,
+                diff_context_lines, include_commit_messages, repo_path, remote, default_base_branch,
+                custom_instructions.
+
         """
         toml_config = load_toml_config()
 
@@ -200,7 +206,9 @@ class PrPromptGenerator:
 
         diff_index = git.get_diff_index(self.diff_context_lines)
 
-        diff_files = get_diff_files(diff_index, self.blacklist_patterns)
+        diff_files = get_diff_files(
+            diff_index, self.blacklist_patterns, self.whitelist_patterns
+        )
 
         builder.add_context_files(
             self.context_patterns, self.blacklist_patterns, diff_files

--- a/src/pr_prompt/generator.py
+++ b/src/pr_prompt/generator.py
@@ -22,7 +22,7 @@ class PrPromptGenerator:
     Example:
         ```python
         generator = PrPromptGenerator(
-            blacklist_patterns=["*.lock"],
+            blacklist_patterns=["*.lock", "*.png"],
             context_patterns=["AGENTS.md"],
             include_commit_messages=True,
             default_base_branch="origin/main",
@@ -34,7 +34,8 @@ class PrPromptGenerator:
 
     Attributes:
         blacklist_patterns: File patterns to exclude from diffs and context file inclusion.
-            Default: `["*.lock"]`.
+            Default: `["*.lock", "package-lock.json", "*.exe",
+                "*.dll","*.bin","*.pyc", "*.whl", "*.jar", "*.svg", "*.png"]`.
         context_patterns: File patterns to include in prompt (after blacklist filtering).
             Used for including documentation that provides context.
             Default: `["AGENTS.md"]`.
@@ -54,7 +55,20 @@ class PrPromptGenerator:
             Default: `None`.
     """
 
-    blacklist_patterns: list[str] = field(default_factory=lambda: ["*.lock"])
+    blacklist_patterns: list[str] = field(
+        default_factory=lambda: [
+            "*.lock",
+            "package-lock.json",
+            "*.exe",
+            "*.dll",
+            "*.bin",
+            "*.pyc",
+            "*.whl",
+            "*.jar",
+            "*.svg",
+            "*.png",
+        ]
+    )
     context_patterns: list[str] = field(default_factory=lambda: ["AGENTS.md"])
 
     fetch_base: bool = False

--- a/src/pr_prompt/markdown_builder.py
+++ b/src/pr_prompt/markdown_builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -68,7 +70,7 @@ class MarkdownBuilder:
 
     def add_context_files(
         self,
-        context_patterns: list[str],
+        context_patterns: list[str] | None,
         blacklist_patterns: list[str],
         diff_files: dict[str, DiffFile],
     ) -> None:
@@ -86,6 +88,8 @@ class MarkdownBuilder:
 
         self.sections.append(MarkdownSection(title="Context Files"))
         for file_path in context_files:
+            if self.git_client.is_binary(self.git_client.head_ref, file_path):
+                continue
             content = self.git_client.get_file_content(
                 self.git_client.head_ref, file_path
             )

--- a/src/pr_prompt/utils/diff_parser.py
+++ b/src/pr_prompt/utils/diff_parser.py
@@ -107,6 +107,10 @@ def get_content_parts(
         content_parts.append("[Diff ignored]")
         return content_parts
 
+    if _is_binary_diff(diff):
+        content_parts.append("[Binary file]")
+        return content_parts
+
     if change_type == ChangeType.ADDED and diff.b_blob and diff.b_path:
         content = read_blob(diff.b_blob)
         content_parts.append(get_markdown_content(diff.b_path, content))
@@ -141,3 +145,13 @@ def read_diff(diff: Diff) -> str:
         if isinstance(diff.diff, bytes)
         else diff.diff
     )
+
+
+def _is_binary_diff(diff: Diff) -> bool:
+    """Check if a diff involves binary files by inspecting blob content for null bytes."""
+    for blob in (diff.a_blob, diff.b_blob):
+        if blob is not None:
+            chunk: bytes = blob.data_stream.read(8192)
+            if b"\x00" in chunk:
+                return True
+    return False

--- a/src/pr_prompt/utils/diff_parser.py
+++ b/src/pr_prompt/utils/diff_parser.py
@@ -109,9 +109,9 @@ def get_content_parts(
         content_parts.append(get_markdown_content(diff.a_path, content))
 
     elif diff.diff:
-        content_parts.append("```diff")
+        content_parts.append("~~~diff")
         diff_content = read_diff(diff)
-        content_parts.append(f"{diff_content}```")
+        content_parts.append(f"{diff_content}~~~")
 
     return content_parts
 

--- a/src/pr_prompt/utils/diff_parser.py
+++ b/src/pr_prompt/utils/diff_parser.py
@@ -43,7 +43,9 @@ class DiffFile:
 
 
 def get_diff_files(
-    diffs: DiffIndex[Diff], blacklist_patterns: list[str]
+    diffs: DiffIndex[Diff],
+    blacklist_patterns: list[str],
+    whitelist_patterns: Optional[list[str]] = None,
 ) -> dict[str, DiffFile]:
     """Convert GitPython Diff objects to DiffFile objects."""
     diff_files = {}
@@ -51,6 +53,11 @@ def get_diff_files(
     for diff in diffs:
         file_path = diff.b_path or diff.a_path
         if file_path:
+            if whitelist_patterns and not FileFilter.is_match(
+                file_path, whitelist_patterns
+            ):
+                continue
+
             is_blacklisted = FileFilter.is_match(file_path, blacklist_patterns)
 
             change_type = get_change_type(diff)

--- a/src/pr_prompt/utils/git_client.py
+++ b/src/pr_prompt/utils/git_client.py
@@ -65,14 +65,32 @@ class GitClient:
             str(item.path) for item in commit.tree.traverse() if isinstance(item, Blob)
         ]
 
+    def is_binary(self, ref: str, file_path: str) -> bool:
+        """Check if a file is binary at a given ref. Symlinks are not binary."""
+        commit = self.repo.commit(ref)
+        blob = commit.tree[file_path]
+        if self.is_symlink(blob):
+            return False
+        chunk: bytes = blob.data_stream.read(8192)
+        return b"\x00" in chunk
+
+    def is_symlink(self, blob: Blob) -> bool:
+        """Check if a blob represents a symlink."""
+        return blob.mode == 0o120000  # noqa: PLR2004
+
     def get_file_content(self, ref: str, file_path: str) -> str:
         commit = self.repo.commit(ref)
         blob = commit.tree[file_path]
+        if self.is_symlink(blob):
+            target = blob.data_stream.read().decode("utf-8").strip()
+            resolved = (Path(file_path).parent / target).as_posix()
+            blob = commit.tree[resolved]
         blob_data: bytes = blob.data_stream.read()
         return blob_data.decode("utf-8", errors="replace").strip()
 
     def get_diff_index(self, context_lines: int = 999999) -> DiffIndex[Diff]:
-        """Get the diff index between the merge-base of base and head commits.
+        """
+        Get the diff index between the merge-base of base and head commits.
 
         Uses the merge-base (common ancestor) to produce a three-dot diff,
         matching GitHub's PR diff behavior. Falls back to a direct diff

--- a/src/pr_prompt/utils/git_client.py
+++ b/src/pr_prompt/utils/git_client.py
@@ -40,10 +40,11 @@ class GitClient:
             raise InferBaseBranchError(msg) from err
 
     def fetch_base_branch(self) -> None:
-        """Fetch the base ref if it's a remote branch."""
+        """Fetch the base ref if it's a remote branch and re-resolve base_commit."""
         if self.base_ref.startswith(f"{self.remote.name}/"):
             ref = self.base_ref.removeprefix(f"{self.remote.name}/")
             self.remote.fetch(ref)
+            self.base_commit = self.repo.commit(self.base_ref)
 
     def get_commit_messages(self) -> list[str]:
         """Get list of commit messages between two refs."""
@@ -71,7 +72,16 @@ class GitClient:
         return blob_data.decode("utf-8", errors="replace").strip()
 
     def get_diff_index(self, context_lines: int = 999999) -> DiffIndex[Diff]:
-        return self.base_commit.diff(
+        """Get the diff index between the merge-base of base and head commits.
+
+        Uses the merge-base (common ancestor) to produce a three-dot diff,
+        matching GitHub's PR diff behavior. Falls back to a direct diff
+        if no merge-base exists (e.g., unrelated histories).
+        """
+        merge_bases = self.repo.merge_base(self.base_commit, self.head_commit)
+        effective_base = merge_bases[0] if merge_bases else self.base_commit
+
+        return effective_base.diff(
             self.head_commit,
             create_patch=True,
             unified=context_lines,

--- a/src/pr_prompt/utils/markdown_parser.py
+++ b/src/pr_prompt/utils/markdown_parser.py
@@ -31,9 +31,4 @@ def get_markdown_content(file_path: str, content: str) -> str:
         "md": "markdown",
     }
     lang = lang_map.get(extension, "text")
-
-    if lang == "markdown":
-        content = f"~~~{lang}\n{content}\n~~~"
-    else:
-        content = f"```{lang}\n{content}\n```"
-    return content
+    return f"~~~{lang}\n{content}\n~~~"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,8 @@ def create_mock_git_client(
     mock_git.get_commit_messages.return_value = commit_messages
     mock_git.fetch_base_branch.return_value = None
     mock_git.get_file_content.return_value = "context file content"
+    mock_git.repo = MagicMock()
+    mock_git.repo.merge_base.return_value = [MagicMock()]
 
     # Create mock diff index with proper structure
     mock_diffs = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def create_mock_git_client(
     mock_git.get_commit_messages.return_value = commit_messages
     mock_git.fetch_base_branch.return_value = None
     mock_git.get_file_content.return_value = "context file content"
+    mock_git.is_binary.return_value = False
     mock_git.repo = MagicMock()
     mock_git.repo.merge_base.return_value = [MagicMock()]
 

--- a/tests/test_pr_prompt.py
+++ b/tests/test_pr_prompt.py
@@ -127,7 +127,7 @@ class TestGitClientMergeBase:
     """Test merge-base diff behavior in GitClient."""
 
     @patch.object(Repo, "__init__", return_value=None)
-    def test_get_diff_index_uses_merge_base(self, _mock_repo_init: MagicMock) -> None:
+    def test_get_diff_index_uses_merge_base(self, _mock_repo_init: MagicMock) -> None:  # noqa: PT019
         """Test that get_diff_index diffs from the merge-base, not base_commit."""
         client = object.__new__(GitClient)
         client.repo = MagicMock(spec=Repo)
@@ -154,7 +154,8 @@ class TestGitClientMergeBase:
 
     @patch.object(Repo, "__init__", return_value=None)
     def test_get_diff_index_falls_back_without_merge_base(
-        self, _mock_repo_init: MagicMock
+        self,
+        _mock_repo_init: MagicMock,  # noqa: PT019
     ) -> None:
         """Test fallback to base_commit when no merge-base exists."""
         client = object.__new__(GitClient)
@@ -170,7 +171,8 @@ class TestGitClientMergeBase:
 
     @patch.object(Repo, "__init__", return_value=None)
     def test_fetch_base_branch_re_resolves_commit(
-        self, _mock_repo_init: MagicMock
+        self,
+        _mock_repo_init: MagicMock,  # noqa: PT019
     ) -> None:
         """Test that fetch_base_branch updates base_commit after fetching."""
         client = object.__new__(GitClient)

--- a/tests/test_pr_prompt.py
+++ b/tests/test_pr_prompt.py
@@ -2,9 +2,12 @@
 
 from unittest.mock import MagicMock, patch
 
+from git import Repo
+
 from pr_prompt.generator import PrPromptGenerator
 from pr_prompt.markdown_builder import MarkdownBuilder
 from pr_prompt.utils import FileFilter, get_diff_files
+from pr_prompt.utils.git_client import GitClient
 
 from .conftest import create_mock_git_client
 
@@ -75,7 +78,7 @@ class TestMarkdownBuilder:
         mock_git = create_mock_git_client(files=["main.py", "example.py"])
 
         builder = MarkdownBuilder(mock_git)
-        builder.add_context_files(["example.py"])
+        builder.add_context_files(["example.py"], [], {})
 
         prompt = builder.build()
         assert "context file content" in prompt
@@ -118,3 +121,71 @@ class TestPrPrompt:
         assert "main.py" in prompt
         assert "File diffs" in prompt
         assert "File diffs" in prompt
+
+
+class TestGitClientMergeBase:
+    """Test merge-base diff behavior in GitClient."""
+
+    @patch.object(Repo, "__init__", return_value=None)
+    def test_get_diff_index_uses_merge_base(self, _mock_repo_init: MagicMock) -> None:
+        """Test that get_diff_index diffs from the merge-base, not base_commit."""
+        client = object.__new__(GitClient)
+        client.repo = MagicMock(spec=Repo)
+
+        merge_base_commit = MagicMock()
+        client.base_commit = MagicMock()
+        client.head_commit = MagicMock()
+        client.repo.merge_base.return_value = [merge_base_commit]
+
+        client.get_diff_index(context_lines=3)
+
+        client.repo.merge_base.assert_called_once_with(
+            client.base_commit, client.head_commit
+        )
+        merge_base_commit.diff.assert_called_once_with(
+            client.head_commit,
+            create_patch=True,
+            unified=3,
+            diff_algorithm="histogram",
+            find_renames=50,
+            function_context=True,
+        )
+        client.base_commit.diff.assert_not_called()
+
+    @patch.object(Repo, "__init__", return_value=None)
+    def test_get_diff_index_falls_back_without_merge_base(
+        self, _mock_repo_init: MagicMock
+    ) -> None:
+        """Test fallback to base_commit when no merge-base exists."""
+        client = object.__new__(GitClient)
+        client.repo = MagicMock(spec=Repo)
+
+        client.base_commit = MagicMock()
+        client.head_commit = MagicMock()
+        client.repo.merge_base.return_value = []
+
+        client.get_diff_index()
+
+        client.base_commit.diff.assert_called_once()
+
+    @patch.object(Repo, "__init__", return_value=None)
+    def test_fetch_base_branch_re_resolves_commit(
+        self, _mock_repo_init: MagicMock
+    ) -> None:
+        """Test that fetch_base_branch updates base_commit after fetching."""
+        client = object.__new__(GitClient)
+        client.repo = MagicMock(spec=Repo)
+        client.remote = MagicMock()
+        client.remote.name = "origin"
+        client.base_ref = "origin/main"
+
+        old_commit = MagicMock()
+        new_commit = MagicMock()
+        client.base_commit = old_commit
+        client.repo.commit.return_value = new_commit
+
+        client.fetch_base_branch()
+
+        client.remote.fetch.assert_called_once_with("main")
+        client.repo.commit.assert_called_once_with("origin/main")
+        assert client.base_commit is new_commit


### PR DESCRIPTION
### Git diff behavior:

Use merge-base (common ancestor) for diffs instead of diffing directly against the base commit, matching GitHub's PR diff behavior
Re-resolve base_commit after fetching the base branch

### File filtering:

Add whitelist_patterns option to limit diffs to only matching files
Automatically detect and skip binary files in diffs and context files
Follow symlinks when reading context file content
Update default blacklist_patterns to ["*.lock", "package-lock.json"]
Change default context_patterns from ["AGENTS.md"] to None

### Markdown output:

Use ~~~ instead of ``` for fencing diff blocks and file content, avoiding escaping issues when the content itself contains triple backticks

### CLI:

Add --whitelist option

### Motivation
The direct two-dot diff against the base commit produced misleading results when the base branch had advanced since the feature branch was created. Using the merge-base aligns the tool's output with what GitHub shows in a PR. The whitelist option gives users finer control over which files appear in the prompt. Binary file detection prevents garbled content from polluting prompts, and the fencing change (~~~) avoids broken markdown when diffed code contains triple backticks.`` for fencing diff blocks and file content, avoiding escaping issues when the content itself contains triple backticks
